### PR TITLE
Enable plugin for forex key only

### DIFF
--- a/classes/class-wc-gateway-paynow.php
+++ b/classes/class-wc-gateway-paynow.php
@@ -161,9 +161,22 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 
         $user_currency = get_woocommerce_currency();
 
-        $is_available_currency = in_array( $user_currency, $this->available_currencies );
+		$is_available_currency = in_array( $user_currency, $this->available_currencies );
+		
+		$authSet = false;
 
-		if ( $is_available_currency && $this->enabled == 'yes' && $this->settings['merchant_id'] != '' && $this->settings['merchant_key'] != '' && $this->settings['paynow_initiate_transaction_url'] != '' )
+		if ($user_currency == 'ZWL') {
+			$authSet = $this->settings['merchant_id'] != '' && $this->settings['merchant_key'] != '';
+		} elseif($user_currency == 'USD') {
+			$authSet = $this->settings['forex_merchant_id'] != '' && $this->settings['forex_merchant_key'] != '';
+		}
+
+		if ( 
+			$is_available_currency 
+			&& $this->enabled == 'yes' 
+			&& $authSet
+			&& $this->settings['paynow_initiate_transaction_url'] != '' 
+		)
 			$is_available = true;
 
         return $is_available;

--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -5,7 +5,7 @@
 	Description: A payment gateway for Zimbabwean payment system, Paynow.
 	Author: Webdev
 
-	Version: 1.3.0
+	Version: 1.3.1
 	Author URI: http://www.paynow.co.zw/
 	Requires at least: 3.5
 	Tested up to: 4.1


### PR DESCRIPTION
The plugin would not enable if just the forex integration key and ID were set.
This update toggles the required currency based on selected currency