### PR TITLE
Bugfix: Wakeup magic method defined in woocommerce_paynow_init should…

### DIFF
--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -54,7 +54,7 @@ function woocommerce_paynow_init() {
 
 		public function __clone(){}
 
-		private function __wakeup() {}
+		public function __wakeup() {}
 
 		public function __construct()
 		{


### PR DESCRIPTION
Bugfix: Wakeup magic method defined in woocommerce_paynow_init should have public visibility for php8.x compatibility