### PR TITLE
Bugfix: Order cancelled redirect action handler raises warning and so…

### DIFF
--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -105,7 +105,7 @@ function woocommerce_paynow_init() {
 			$order = new WC_Order($order_id);
 			$meta = get_post_meta( $order_id, '_wc_paynow_payment_meta', true );
 			
-			if ( strtolower( $meta['Status'] ) == ps_cancelled ) {
+			if ( !empty($meta['Status']) && strtolower( $meta['Status'] ) == ps_cancelled ) {
 				wc_add_notice( __( 'You cancelled your payment on Paynow.', 'woocommerce' ), 'error' );
 				// wp_redirect( $order->get_cancel_order_url() );
 				wp_redirect( $order->get_checkout_payment_url() );


### PR DESCRIPTION
…metimes exception when non Paynow payment method is used

Add check to verify that `$meta['Status']` is defined in the function `order_cancelled_redirect`

The bug occurs because the handler/function (`order_cancelled_redirect`) assumes `get_post_meta( $order_id, '_wc_paynow_payment_meta', true );` will always return an array but this is just an empty string when a different payment method is used other than Paynow.