### PR TITLE
fix: Adjust code standard to match required by wooocommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
-/**
- * Plugin Name: Paynow
- * Plugin URI: http://woocommerce.com/products/paynow/
- * Description: A payment gateway for Paynow.
- * Version: 1.3.0
- * Author: Paynow Zimbabwe
- * Author URI: https://paynow.co.zw/
- * Developer: Paynow Zimbabwe
- * Developer URI: https://paynow.co.zw/
- * Text Domain: paynow
- * Domain Path: /languages
- *
- * WC requires at least: 2.2
- * WC tested up to: 2.3
- *
- */
+# Paynow for WooCommerce 
+
+A payment gateway for Paynow. A Paynow merchant account, merchant key and merchant ID are required for this gateway to function.
+
+## Important Note
+
+An SSL certificate is recommended for additional safety and security for your customers.
+
+Install like any other Wordpress plugin, then Paynow appears as a payment option on WooCommerce.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
-# Paynow for WooCommerce 
-
-A payment gateway for Paynow. A Paynow merchant account, merchant key and merchant ID are required for this gateway to function.
-
-## Important Note
-
-An SSL certificate is recommended for additional safety and security for your customers.
-
-Install like any other Wordpress plugin, then Paynow appears as a payment option on WooCommerce.
+/**
+ * Plugin Name: Paynow
+ * Plugin URI: http://woocommerce.com/products/paynow/
+ * Description: A payment gateway for Paynow.
+ * Version: 1.3.0
+ * Author: Paynow Zimbabwe
+ * Author URI: https://paynow.co.zw/
+ * Developer: Paynow Zimbabwe
+ * Developer URI: https://paynow.co.zw/
+ * Text Domain: paynow
+ * Domain Path: /languages
+ *
+ * WC requires at least: 2.2
+ * WC tested up to: 2.3
+ *
+ */

--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,16 @@
+/**
+ * Plugin Name: Paynow
+ * Plugin URI: http://woocommerce.com/products/paynow/
+ * Description: A payment gateway for Paynow.
+ * Version: 1.3.0
+ * Author: Paynow Zimbabwe
+ * Author URI: https://paynow.co.zw/
+ * Developer: Paynow Zimbabwe
+ * Developer URI: https://paynow.co.zw/
+ * Text Domain: paynow
+ * Domain Path: /languages
+ *
+ * WC requires at least: 2.2
+ * WC tested up to: 2.3
+ *
+ */

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,28 +1,29 @@
-*** Paynow Changelog ***
+=== Paynow For Woocommerce ===
 
-2 July, 2014 - version 1.0
- * First Release
+== Archived Changelog Entries ==
+= 1.0 =
+ *Release Date - 2 July 2014*
 
-*** Paynow Changelog ***
+= 1.2.0 =
+*Release Date - 28 March 2019*
 
-16 July, 2014 - version 1.0
- * First Release
--installable, notify url tested, payment info updating
+* restructured the plugin to align it with woocommerce standards and OOP
+* removed unused code
+* removed all curl requests and replaced with wp_remote
+* Added multisite support
 
-28 March 2019
-1.2.0
-- restructured the plugin to align it with woocommerce standards and OOP
-- removed unused code
-- removed all curl requests and replaced with wp_remote
-- Added multisite support
+= 1.2.1 =
+*Release Date - 13 May 2020*
+* fixed plugin not appearing on multisite if not network activated
 
-1.2.1
-- fixed plugin not appearing on multisite if not network activated
+= 1.2.2 =
+*Release Date - 14 May 2020*
+* fixed bug where a cancelled still redirected the customer to the order received page. it now redirects them to the order cancelled page.
 
-13 May 2020
-1.2.2
-- fixed bug where a cancelled still redirected the customer to the order received page. it now redirects them to the order cancelled page.
+= 1.3.0 = 
+*Release Date - 14 May 2020*
+* Added multi currency support
 
-13 May 2020
-1.3.0
-- Added multi currency support
+= 1.3.1 =
+*Release Date 30 September 2023*
+* fixed Code formating to match  woocommerce and Wordpress standards

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,29 +1,22 @@
-=== Paynow For Woocommerce ===
+*** Paynow Changelog***
 
-== Archived Changelog Entries ==
-= 1.0 =
- *Release Date - 2 July 2014*
+2023-09-30 - version 1.3.1
+* fixed Code formating to match  woocommerce and Wordpress standards
 
-= 1.2.0 =
-*Release Date - 28 March 2019*
+2020-05-14 - version 1.3.0
+* Added multi currency support
 
+2020-05-14 - version 1.2.2
+* fixed bug where a cancelled still redirected the customer to the order received page. it now redirects them to the order cancelled page.
+
+2020-05-13 - version 1.2.1
+* fixed plugin not appearing on multisite if not network activated
+
+2019-03-28 - version 1.2.0
 * restructured the plugin to align it with woocommerce standards and OOP
 * removed unused code
 * removed all curl requests and replaced with wp_remote
 * Added multisite support
 
-= 1.2.1 =
-*Release Date - 13 May 2020*
-* fixed plugin not appearing on multisite if not network activated
-
-= 1.2.2 =
-*Release Date - 14 May 2020*
-* fixed bug where a cancelled still redirected the customer to the order received page. it now redirects them to the order cancelled page.
-
-= 1.3.0 = 
-*Release Date - 14 May 2020*
-* Added multi currency support
-
-= 1.3.1 =
-*Release Date 30 September 2023*
-* fixed Code formating to match  woocommerce and Wordpress standards
+2014-07-02 - version 1.0
+*Inital Release

--- a/classes/class-wc-gateway-paynow-helper.php
+++ b/classes/class-wc-gateway-paynow-helper.php
@@ -39,7 +39,7 @@ class WC_Paynow_Helper {
 
 		foreach ($fields as $key => $value) {
 			$fields_string .= $delim . $key . '=' . $value;
-			$delim = '';
+			$delim = '&';
 		}
 
 		return $fields_string;

--- a/classes/class-wc-gateway-paynow-helper.php
+++ b/classes/class-wc-gateway-paynow-helper.php
@@ -1,56 +1,89 @@
-<?php 
+<?php
+
+/**
+ * WooCommerce PayNow Helper Class.
+ *
+ * This class provides helper methods for integrating with the PayNow payment gateway in WooCommerce.
+ */
 class WC_Paynow_Helper {
-    function ParseMsg($msg) {
-        // convert to array data
-        $parts = explode("&",$msg);
-        $result = array();
 
-        foreach($parts as $i => $value) {
-            $bits = explode("=", $value, 2);
-            $result[$bits[0]] = urldecode($bits[1]);
-        }
-    
-        return $result;
-    }
-    
-    function UrlIfy($fields) {
-        // url-ify the data for the POST
-        $delim = "";
-        $fields_string = "";
+	/**
+	 * Parse a PayNow message into an associative array.
+	 *
+	 * @param string $msg The PayNow message string.
+	 * @return array An associative array representing the parsed message.
+	 */
+	public function parseMsg( $msg) {
+		// Convert to array data
+		$parts = explode('&', $msg);
+		$result = array();
 
-        foreach($fields as $key=>$value) {
-            $fields_string .= $delim . $key . '=' . $value;
-            $delim = "&";
-        }
-    
-        return $fields_string;
-    }
-    
-    function CreateHash($values, $MerchantKey){
-        $string = "";
+		foreach ($parts as $i => $value) {
+			$bits = explode('=', $value, 2);
+			$result[$bits[0]] = urldecode($bits[1]);
+		}
 
-        foreach($values as $key=>$value) {
-            if( strtoupper($key) != "HASH" ){
-                $string .= $value;
-            }
-        }
+		return $result;
+	}
 
-        $string .= $MerchantKey;
-        $hash = hash("sha512", $string);
+	/**
+	 * Convert an associative array to a URL-encoded string.
+	 *
+	 * @param array $fields An associative array of data to be URL-encoded.
+	 * @return string A URL-encoded string.
+	 */
+	public function urlIfy( $fields) {
+		// URL-ify the data for the POST
+		$delim = '';
+		$fields_string = '';
 
-        return strtoupper($hash);
-    }
-    
-    function CreateMsg($values, $MerchantKey){
-        $fields = array();
+		foreach ($fields as $key => $value) {
+			$fields_string .= $delim . $key . '=' . $value;
+			$delim = '';
+		}
 
-        foreach($values as $key=>$value) {
-           $fields[$key] = urlencode($value);
-        }
-    
-        $fields["hash"] = urlencode($this->CreateHash($values, $MerchantKey));
-        $fields_string = $this->UrlIfy($fields);
+		return $fields_string;
+	}
 
-        return $fields_string;
-    }
+	/**
+	 * Create a hash for PayNow using provided values and the MerchantKey.
+	 *
+	 * @param array $values An associative array of values.
+	 * @param string $MerchantKey The PayNow Merchant Key.
+	 * @return string The generated hash.
+	 */
+	public function createHash( $values, $MerchantKey) {
+		$string = '';
+
+		foreach ($values as $key => $value) {
+			if (strtoupper($key) != 'HASH') {
+				$string .= $value;
+			}
+		}
+
+		$string .= $MerchantKey;
+		$hash = hash('sha512', $string);
+
+		return strtoupper($hash);
+	}
+
+	/**
+	 * Create a PayNow message string with URL-encoded values and a hash.
+	 *
+	 * @param array $values An associative array of values.
+	 * @param string $MerchantKey The PayNow Merchant Key.
+	 * @return string A URL-encoded PayNow message string.
+	 */
+	public function createMsg( $values, $MerchantKey) {
+		$fields = array();
+
+		foreach ($values as $key => $value) {
+			$fields[$key] = urlencode($value);
+		}
+
+		$fields['hash'] = urlencode($this->createHash($values, $MerchantKey));
+		$fields_string = $this->urlIfy($fields);
+
+		return $fields_string;
+	}
 }

--- a/classes/class-wc-gateway-paynow-helper.php
+++ b/classes/class-wc-gateway-paynow-helper.php
@@ -13,7 +13,7 @@ class WC_Paynow_Helper {
 	 * @param string $msg The PayNow message string.
 	 * @return array An associative array representing the parsed message.
 	 */
-	public function parseMsg( $msg) {
+	public function parseMsg( $msg ) {
 		// Convert to array data
 		$parts = explode('&', $msg);
 		$result = array();
@@ -32,7 +32,7 @@ class WC_Paynow_Helper {
 	 * @param array $fields An associative array of data to be URL-encoded.
 	 * @return string A URL-encoded string.
 	 */
-	public function urlIfy( $fields) {
+	public function urlIfy( $fields ) {
 		// URL-ify the data for the POST
 		$delim = '';
 		$fields_string = '';
@@ -52,7 +52,7 @@ class WC_Paynow_Helper {
 	 * @param string $MerchantKey The PayNow Merchant Key.
 	 * @return string The generated hash.
 	 */
-	public function createHash( $values, $MerchantKey) {
+	public function createHash( $values, $MerchantKey ) {
 		$string = '';
 
 		foreach ($values as $key => $value) {
@@ -74,7 +74,7 @@ class WC_Paynow_Helper {
 	 * @param string $MerchantKey The PayNow Merchant Key.
 	 * @return string A URL-encoded PayNow message string.
 	 */
-	public function createMsg( $values, $MerchantKey) {
+	public function createMsg( $values, $MerchantKey ) {
 		$fields = array();
 
 		foreach ($values as $key => $value) {

--- a/classes/class-wc-gateway-paynow.php
+++ b/classes/class-wc-gateway-paynow.php
@@ -26,7 +26,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		$this->has_fields = true;
 
 		// this is the name of the class. Mainly used in the callback to trigger wc-api handler in this class
-		$this->callback	= strtolower(get_class($this));
+		$this->callback = strtolower(get_class($this));
 
 		// Setup available countries.
 		$this->available_countries = array( 'ZW' );

--- a/classes/class-wc-gateway-paynow.php
+++ b/classes/class-wc-gateway-paynow.php
@@ -7,7 +7,7 @@
  *
  * @todo - Improve the naming of variables where possible
  * @class wc_gateway_paynow
- * @package	WooCommerce
+ * @package WooCommerce
  * Author: Webdev
  *
  */
@@ -26,7 +26,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		$this->has_fields = true;
 
 		// this is the name of the class. Mainly used in the callback to trigger wc-api handler in this class
-		$this->callback	=  strtolower(get_class($this));
+		$this->callback	= strtolower(get_class($this));
 
 		// Setup available countries.
 		$this->available_countries = array( 'ZW' );

--- a/classes/class-wc-gateway-paynow.php
+++ b/classes/class-wc-gateway-paynow.php
@@ -1,36 +1,38 @@
 <?php
+
 /**
  * Paynow Payment Gateway
  *
  * Provides a Paynow Payment Gateway.
+ *
  * @todo - Improve the naming of variables where possible
  * @class 		wc_gateway_paynow
  * @package		WooCommerce
- * @category	Payment Gateways
- * @author		Webdev
+ * Author: Webdev
  *
  */
- 
+
 class WC_Gateway_Paynow extends WC_Payment_Gateway {
+
 
 	public $version = WC_PAYNOW_VERSION;
 
 	public function __construct() {
-        global $woocommerce;
-        $this->id			= 'paynow';
-        $this->method_title = __( 'Paynow', 'woothemes' );
-        $this->method_description = 'Have your customers pay using Zimbabwean payment methods.';
-        $this->icon 		= $this->plugin_url() . '/assets/images/icon.png';
+		global $woocommerce;
+		$this->id			= 'paynow';
+		$this->method_title = __('Paynow', 'woothemes');
+		$this->method_description = 'Have your customers pay using Zimbabwean payment methods.';
+		$this->icon 		= $this->plugin_url() . '/assets/images/icon.png';
 		$this->has_fields 	= true;
 
 		// this is the name of the class. Mainly used in the callback to trigger wc-api handler in this class
-		$this->callback		=  strtolower( get_class($this) );
+		$this->callback		=  strtolower(get_class($this));
 
 		// Setup available countries.
-		$this->available_countries = array( 'ZW' );
+		$this->available_countries = array('ZW');
 
 		// Setup available currency codes.
-		$this->available_currencies = array( 'USD', 'ZWL' ); // nostro / rtgs ?
+		$this->available_currencies = array('USD', 'ZWL'); // nostro / rtgs ?
 
 		// Load the form fields.
 		$this->init_form_fields();
@@ -51,135 +53,140 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		$this->title = $this->settings['title'];
 
 		// this is the url paynow will send it's response to
-		$this->response_url	= add_query_arg( 'wc-api', $this->callback , home_url( '/' ) );
-		
+		$this->response_url	= add_query_arg('wc-api', $this->callback, home_url('/'));
+
 		// register a handler for wc-api calls to this payment method
-		add_action( 'woocommerce_api_' . $this->callback , array( &$this, 'paynow_checkout_return_handler' ) );
-		
+		add_action('woocommerce_api_' . $this->callback, array(&$this, 'paynow_checkout_return_handler'));
+
 		/* 1.6.6 */
-		add_action( 'woocommerce_update_options_payment_gateways', array( $this, 'process_admin_options' ) );
+		add_action('woocommerce_update_options_payment_gateways', array($this, 'process_admin_options'));
 
 		/* 2.0.0 */
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
 
-		
-		add_action( 'woocommerce_receipt_paynow', array( $this, 'receipt_page' ) );
+
+		add_action('woocommerce_receipt_paynow', array($this, 'receipt_page'));
 
 		// Check if the base currency supports this gateway.
-		if ( ! $this->is_valid_for_use() )
+		if (!$this->is_valid_for_use()) {
 			$this->enabled = false;
-    }
+		}
+	}
 
 	/**
-     * Initialise Gateway Settings Form Fields
-     *
-     * @since 1.0.0
-     */
-    function init_form_fields () {
+	 * Initialise Gateway Settings Form Fields
+	 *
+	 * @since 1.0.0
+	 */
+	public function init_form_fields() {
 
-    	$this->form_fields = array(
-		'enabled' => array(
-			'title' => __( 'Enable/Disable', 'woothemes' ),
-			'label' => __( 'Enable Paynow', 'woothemes' ),
-			'type' => 'checkbox',
-			'description' => __( 'This controls whether or not this gateway is enabled within WooCommerce.', 'woothemes' ),
-			'default' => 'yes'
-		),
-		'title' => array(
-			'title' => __( 'Title', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This controls the title which the user sees during checkout.', 'woothemes' ),
-			'default' => __( 'Paynow', 'woothemes' )
-		),
-		'description' => array(
-			'title' => __( 'Description', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This controls the description which the user sees during checkout.', 'woothemes' ),
-			'default' => ''
-		),
-		'merchant_id' => array(
-			'title' => __( 'Merchant ID (local)', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This is the merchant ID, received from Paynow.', 'woothemes' ),
-			'default' => ''
-		),
-		'merchant_key' => array(
-			'title' => __( 'Merchant Key (local)', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This is the merchant key, received from Paynow.', 'woothemes' ),
-			'default' => ''
-		),
-		'forex_merchant_id' => array(
-			'title' => __( 'Merchant ID (USD)', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This is the merchant ID, received from Paynow.', 'woothemes' ),
-			'default' => ''
-		),
-		'forex_merchant_key' => array(
-			'title' => __( 'Merchant Key (USD)', 'woothemes' ),
-			'type' => 'text',
-			'description' => __( 'This is the merchant key, received from Paynow.', 'woothemes' ),
-			'default' => ''
-		),
-		'paynow_initiate_transaction_url' => array(
-				'title' => __( 'Paynow Initiate Transaction URL', 'woothemes' ),
+		$this->form_fields = array(
+			'enabled' => array(
+				'title' => __('Enable/Disable', 'woothemes'),
+				'label' => __('Enable Paynow', 'woothemes'),
+				'type' => 'checkbox',
+				'description' => __('This controls whether or not this gateway is enabled within WooCommerce.', 'woothemes'),
+				'default' => 'yes'
+			),
+			'title' => array(
+				'title' => __('Title', 'woothemes'),
 				'type' => 'text',
-				'label' => __( 'Paynow Initiate Transaction URL.', 'woothemes' ),
+				'description' => __('This controls the title which the user sees during checkout.', 'woothemes'),
+				'default' => __('Paynow', 'woothemes')
+			),
+			'description' => array(
+				'title' => __('Description', 'woothemes'),
+				'type' => 'text',
+				'description' => __('This controls the description which the user sees during checkout.', 'woothemes'),
+				'default' => ''
+			),
+			'merchant_id' => array(
+				'title' => __('Merchant ID (local)', 'woothemes'),
+				'type' => 'text',
+				'description' => __('This is the merchant ID, received from Paynow.', 'woothemes'),
+				'default' => ''
+			),
+			'merchant_key' => array(
+				'title' => __('Merchant Key (local)', 'woothemes'),
+				'type' => 'text',
+				'description' => __('This is the merchant key, received from Paynow.', 'woothemes'),
+				'default' => ''
+			),
+			'forex_merchant_id' => array(
+				'title' => __('Merchant ID (USD)', 'woothemes'),
+				'type' => 'text',
+				'description' => __('This is the merchant ID, received from Paynow.', 'woothemes'),
+				'default' => ''
+			),
+			'forex_merchant_key' => array(
+				'title' => __('Merchant Key (USD)', 'woothemes'),
+				'type' => 'text',
+				'description' => __('This is the merchant key, received from Paynow.', 'woothemes'),
+				'default' => ''
+			),
+			'paynow_initiate_transaction_url' => array(
+				'title' => __('Paynow Initiate Transaction URL', 'woothemes'),
+				'type' => 'text',
+				'label' => __('Paynow Initiate Transaction URL.', 'woothemes'),
 				'default' => 'https://www.paynow.co.zw/Interface/InitiateTransaction'
 			)
 		);
+	} // End init_form_fields()
 
-    } // End init_form_fields()
-
-    /**
+	/**
 	 * Get the plugin URL
 	 *
 	 * @since 1.0.0
 	 */
-	function plugin_url() {
-		if( isset( $this->plugin_url ) )
+	public function plugin_url() {
+		if (isset($this->plugin_url)) {
 			return $this->plugin_url;
+		}
 
-		if ( is_ssl() ) {
-			return $this->plugin_url = str_replace( 'http://', 'https://', WP_PLUGIN_URL ) . "/" . plugin_basename( dirname( dirname( __FILE__ ) ) );
+		if (is_ssl()) {
+			$this->plugin_url = str_replace('http://', 'https://', WP_PLUGIN_URL) . '/' . plugin_basename(dirname(dirname(__FILE__)));
+
+			return $this->plugin_url;
 		} else {
-			return $this->plugin_url = WP_PLUGIN_URL . "/" . plugin_basename( dirname( dirname( __FILE__ ) ) );
+			$this->plugin_url = WP_PLUGIN_URL . '/' . plugin_basename(dirname(dirname(__FILE__)));
+			return $this->plugin_url;
 		}
 	} // End plugin_url()
 
-    /**
-     * is_valid_for_use()
-     *
-     * Check if this gateway is enabled and available in the base currency being traded with.
-     *
-     * @since 1.0.0
-     */
-	function is_valid_for_use() {
+	/**
+	 * Check if this is available for use.
+	 *
+	 * Check if this gateway is enabled and available in the base currency being traded with.
+	 *
+	 * @since 1.0.0
+	 */
+	public function is_valid_for_use() {
 		global $woocommerce;
 
 		$is_available = false;
 
-        $user_currency = get_woocommerce_currency();
+		$user_currency = get_woocommerce_currency();
 
-		$is_available_currency = in_array( $user_currency, $this->available_currencies );
-		
+		$is_available_currency = in_array($user_currency, $this->available_currencies);
+
 		$authSet = false;
 
-		if ($user_currency == 'ZWL') {
-			$authSet = $this->settings['merchant_id'] != '' && $this->settings['merchant_key'] != '';
-		} elseif($user_currency == 'USD') {
-			$authSet = $this->settings['forex_merchant_id'] != '' && $this->settings['forex_merchant_key'] != '';
+		if ('ZWL' == $user_currency  ) {
+			$authSet =  '' != $this->settings['merchant_id'] && '' != $this->settings['merchant_key'];
+		} elseif ('USD' == $user_currency) {
+			$authSet = '' !=  $this->settings['forex_merchant_id'] &&  '' != $this->settings['forex_merchant_key'];
 		}
 
-		if ( 
-			$is_available_currency 
-			&& $this->enabled == 'yes' 
+		if (
+			$is_available_currency
+			&& 'yes' == $this->enabled 
 			&& $authSet
-			&& $this->settings['paynow_initiate_transaction_url'] != '' 
-		)
+			&&  '' != $this->settings['paynow_initiate_transaction_url']
+		) {
 			$is_available = true;
+		}
 
-        return $is_available;
+		return $is_available;
 	} // End is_valid_for_use()
 
 	/**
@@ -192,51 +199,64 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		// $this->log( '' );
 		// $this->log( '', true );
 
-    	?>
-    	<h3><?php _e( 'Paynow', 'woothemes' ); ?></h3>
-    	<p><?php printf( __( 'Paynow works by sending the user to %sPaynow%s to enter their payment information.', 'woothemes' ), '<a href="http://www.paynow.co.zw/">', '</a>' ); ?></p>
+		?>
+		<h3>
+		<?php /* translators: %s: Paynow */ ?>
 
-    	<?php
-				
-    	if ( in_array( get_woocommerce_currency(), $this->available_currencies) ) {
-    		?><table class="form-table"><?php
-			// Generate the HTML For the settings form.
-    		$this->generate_settings_html();
-    		?></table><!--/.form-table--><?php
+			<?php esc_html_e('Paynow', 'woothemes'); ?>
+		</h3>
+		<p>
+		<?php /* translators: %s: Paynow description */ ?>
+			<?php printf(esc_html_e('Paynow works by sending the user to %1$sPaynow%2$s to enter their payment information.', 'woothemes'), '<a href="http://www.paynow.co.zw/">', '</a>'); ?></p>
+
+		<?php
+
+		if (in_array(get_woocommerce_currency(), $this->available_currencies)) {
+			?>
+		<table class="form-table">
+		<?php
+										// Generate the HTML For the settings form.
+										$this->generate_settings_html();
+			?>
+										</table><!--/.form-table-->
+										<?php
 		} else {
 			?>
-			<div class="inline error"><p><strong><?php _e( 'Gateway Disabled', 'woothemes' ); ?></strong> <?php echo sprintf( __( 'Choose United States Dollar ($/USD) as your store currency in <a href="%s">Pricing Options</a> to enable the Paynow Gateway.', 'woocommerce' ), admin_url( '?page=woocommerce&tab=catalog' ) ); ?></p></div>
+			<div class="inline error">
+			<?php /* translators: %s: Disabled Gateway */ ?>
+				<p><strong><?php esc_html_e('Gateway Disabled', 'woothemes'); ?></strong> <?php echo sprintf(esc_html_e('Choose United States Dollar ($/USD) as your store currency in <a href="%s">Pricing Options</a> to enable the Paynow Gateway.', 'woocommerce'), esc_html_e(admin_url('?page=woocommerce&tab=catalog'))); ?></p>
+			</div>
 		<?php
 		} // End check currency
 		?>
-    	<?php
-    } // End admin_options()
+<?php
+	} // End admin_options()
 
-    /**
+	/**
 	 * There are no payment fields for Paynow, but we want to show the description if set.
 	 *
 	 * @since 1.0.0
 	 */
-    function payment_fields() {
-    	if ( isset( $this->settings['description'] ) && ( '' != $this->settings['description'] ) ) {
-    		echo wpautop( wptexturize( $this->settings['description'] ) );
-    	}
-    } // End payment_fields()
+	public function payment_fields() {
+		if (isset($this->settings['description']) && ( '' != $this->settings['description'] )) {
+			echo esc_html_e(wpautop(wptexturize($this->settings['description'])));
+		}
+	} // End payment_fields()
 
 	/**
 	 * Process the payment and return the result.
+	 *
 	 * @param int $order_id
 	 * @param string $from tells process payment whether the method call is from paynow return (callback) or not
 	 * @since 1.0.0
 	 */
-	function process_payment( $order_id ) {
+	public function process_payment( $order_id) {
 
-		$order = wc_get_order( $order_id );
+		$order = wc_get_order($order_id);
 		return array(
 			'result' 	=> 'success',
-			'redirect'	=> $order->get_checkout_payment_url( true )
+			'redirect'	=> $order->get_checkout_payment_url(true)
 		);
-
 	}
 
 	/**
@@ -246,30 +266,31 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 	 *
 	 * @since 1.0.0
 	 */
-	function receipt_page( $order_id ) {
+	public function receipt_page( $order_id) {
 		global $woocommerce;
-		
+
 		//get current order
-		$order = wc_get_order( $order_id ); // added code in Woo Commerce that needs to be changed
-		$checkout_url = $order->get_checkout_payment_url( );
-		
+		$order = wc_get_order($order_id); // added code in Woo Commerce that needs to be changed
+		$checkout_url = $order->get_checkout_payment_url();
+
 		// Check payment
-		if ( ! $order_id ) {
+		if (!$order_id) {
 			wp_redirect($checkout_url);
 			exit;
 		} else {
-			$api_request_url =  WC()->api_request_url( $this->callback );
-			$listener_url = add_query_arg( 'order_id' , $order_id, $api_request_url );
-						
+			$api_request_url =  WC()->api_request_url($this->callback);
+			$listener_url = add_query_arg('order_id', $order_id, $api_request_url);
+
 			// Get the return url
-			$return_url = $this->return_url = $this->get_return_url( $order );
+			$return_url = $this->return_url;
+			$return_url = $this->get_return_url($order);
 
 			// get currency
 			$order_currency = $order->get_currency();
-			
+
 			// Setup Paynow arguments
 
-			if ($order_currency == "USD") {
+			if ('USD' == $order_currency) {
 				$MerchantId =       $this->forex_merchant_id;
 				$MerchantKey =    	$this->forex_merchant_key;
 			} else {
@@ -281,10 +302,10 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 
 			$ConfirmUrl =       $listener_url;
 			$ReturnUrl =        $return_url;
-			$Reference =        "Order Number: " . $order->get_order_number();
+			$Reference =        'Order Number: ' . $order->get_order_number();
 			$Amount =           $order->get_total();
-			$AdditionalInfo =   "";
-			$Status =           "Message";
+			$AdditionalInfo =   '';
+			$Status =           'Message';
 			$custEmail = 		$order->billing_email;
 
 			//set POST variables
@@ -298,12 +319,12 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 				'authemail' => $custEmail, // customer email
 				'status' => $Status
 			);
-						
+
 			// should probably use static methods to have WC_Paynow_Helper::CreateMsg($a, $b);
-			$fields_string = (new WC_Paynow_Helper)->CreateMsg($values, $MerchantKey);
+			$fields_string = ( new WC_Paynow_Helper() )->CreateMsg($values, $MerchantKey);
 
 			$url = $this->initiate_transaction_url;
-			
+
 			// send API post request
 			$response = wp_remote_request($url, [
 				'timeout' => 45,
@@ -313,57 +334,49 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 
 			// get the response from paynow
 			$result = $response['body'];
-			
-			if($result)
-			{
-				$msg = (new WC_Paynow_Helper)->ParseMsg($result);
-				
+
+			if ($result) {
+				$msg = ( new WC_Paynow_Helper() )->ParseMsg($result);
+
 				// first check status, take appropriate action
-				if ( strtolower( $msg["status"] ) == strtolower( ps_error ) ){
+				if (strtolower($msg['status']) == strtolower(PS_ERROR)) {
 					wp_redirect($checkout_url);
 					exit;
-				}
-				elseif ( strtolower($msg["status"] ) == strtolower( ps_ok ) ){
-				
+				} elseif (strtolower($msg['status']) == strtolower(PS_OK)) {
+
 					//second, check hash
-					$validateHash = (new WC_Paynow_Helper)->CreateHash($msg, $MerchantKey);
-					if ( $validateHash != $msg["hash"] ) {
-						$error =  "Paynow reply hashes do not match : " . $validateHash . " - " . $msg["hash"];
+					$validateHash = ( new WC_Paynow_Helper() )->CreateHash($msg, $MerchantKey);
+					if ($validateHash != $msg['hash']) {
+						$error =  'Paynow reply hashes do not match : ' . $validateHash . ' - ' . $msg['hash'];
 					} else {
-						
-						$theProcessUrl = $msg["browserurl"];
+
+						$theProcessUrl = $msg['browserurl'];
 
 						//update order data
-						$payment_meta['BrowserUrl'] = $msg["browserurl"];
-						$payment_meta['PollUrl'] = $msg["pollurl"];
-						$payment_meta['PaynowReference'] = $msg["paynowreference"];
-						$payment_meta['Amount'] = $msg["amount"];
-						$payment_meta['Status'] = "Sent to Paynow";
+						$payment_meta['BrowserUrl'] = $msg['browserurl'];
+						$payment_meta['PollUrl'] = $msg['pollurl'];
+						$payment_meta['PaynowReference'] = $msg['paynowreference'];
+						$payment_meta['Amount'] = $msg['amount'];
+						$payment_meta['Status'] = 'Sent to Paynow';
 
 						// if the post meta does not exist, wp calls add_post_meta
-						update_post_meta( $order_id, '_wc_paynow_payment_meta', $payment_meta );
-						
+						update_post_meta($order_id, '_wc_paynow_payment_meta', $payment_meta);
 					}
-				} elseif( strtolower($msg["status"] ) == strtolower( ps_cancelled ) ){
+				} elseif (strtolower($msg['status']) == strtolower(PS_CANCELLED)) {
 					wp_mail('adrian@webdevworld.com', 'WC Test', 'This is a cancelled test.');
-				}else {						
+				} else {
 					//unknown status
-					$error =  "Invalid status in from Paynow, cannot continue lah ;).";
+					$error =  'Invalid status in from Paynow, cannot continue lah ;).';
 				}
+			} else {
+				$error = 'Empty response from network request';
 			}
-			else
-			{
-			   $error = "Empty response from network request";
-			}
-			
+
 			//Choose where to go
-			if(isset($error))
-			{	
+			if (isset($error)) {
 				wp_redirect($checkout_url);
 				exit;
-			}
-			else
-			{ 
+			} else {
 				// redirect user to paynow 
 				wp_redirect($theProcessUrl);
 				exit;
@@ -372,62 +385,58 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 	} // End receipt_page()
 
 	/**
-	 * log()
-	 *
-	 * Log system processes.
+	 *  Log system processes.
 	 *
 	 * @since 1.0.0
 	 */
 
-	function log ( $message, $close = false ) {
+	public function log( $message, $close = false) {
 
 		static $fh = 0;
 
-		if( $close ) {
-            @fclose( $fh );
-        } else {
-            // If file doesn't exist, create it
-            if( !$fh ) {
-                $pathinfo = pathinfo( __FILE__ );
-                $dir = str_replace( '/classes', '/logs', $pathinfo['dirname'] );
-                $fh = @fopen( $dir .'/paynow.log', 'a+' );
-            }
+		if ($close) {
+			@fclose($fh);
+		} else {
+			// If file doesn't exist, create it
+			if (!$fh) {
+				$pathinfo = pathinfo(__FILE__);
+				$dir = str_replace('/classes', '/logs', $pathinfo['dirname']);
+				$fh = @fopen($dir . '/paynow.log', 'a+');
+			}
 
-            // If file was successfully created
-            if( $fh ) {
-                $line = $message ."\n";
+			// If file was successfully created
+			if ($fh) {
+				$line = $message . "\n";
 
-                fwrite( $fh, $line );
-            }
-        }
+				fwrite($fh, $line);
+			}
+		}
 	} // End log()
 
-	
+
 	/**
 	 * Process notify from Paynow
 	 * Called from wc-api to process paynow's response
 	 *
 	 * @since 1.2.0
 	 */
-	function paynow_checkout_return_handler()
-	{
+	public function paynow_checkout_return_handler() {
 		global $woocommerce;
-		
+
 		// Check the request method is POST
-		if ( isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] != 'POST' && !isset($_GET['order_id']) ) {
+		if (isset($_SERVER['REQUEST_METHOD']) && 'POST' != $_SERVER['REQUEST_METHOD']  && !isset($_GET['order_id'])) {
 			return;
 		}
 
-		$order_id = $_GET['order_id'];
-		
-		$order = wc_get_order( $order_id );
-		
-		$payment_meta = get_post_meta( $order_id, '_wc_paynow_payment_meta', true );
-		
-		if($payment_meta)
-		{
-			$url = $payment_meta["PollUrl"];
-			
+		$order_id = sanitize_text_field($_GET['order_id']);
+
+		$order = wc_get_order($order_id);
+
+		$payment_meta = get_post_meta($order_id, '_wc_paynow_payment_meta', true);
+
+		if ($payment_meta) {
+			$url = $payment_meta['PollUrl'];
+
 			//execute post
 			$response = wp_remote_request($url, [
 				'timeout' => 45,
@@ -436,56 +445,44 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 			]);
 
 			$result = $response['body'];
-			
-			if($result)
-			{
-				$msg = (new WC_Paynow_Helper)->ParseMsg($result);
+
+			if ($result) {
+				$msg = ( new WC_Paynow_Helper() )->ParseMsg($result);
 
 				$currency = $order->get_currency();
 
-				$MerchantKey =  $currency == "ZWL" ? $this->merchant_key : $this->forex_merchant_key;
-				$validateHash = (new WC_Paynow_Helper)->CreateHash($msg, $MerchantKey);
-				
-				if($validateHash != $msg["hash"]){
+				$MerchantKey =   'ZWL' == $currency ? $this->merchant_key : $this->forex_merchant_key;
+				$validateHash = ( new WC_Paynow_Helper() )->CreateHash($msg, $MerchantKey);
+
+				if ($validateHash != $msg['hash']) {
 					// hashes do not match 
 					// look at throwing clean errors
 					exit;
-				}
-				else
-				{
+				} else {
 
-					$payment_meta['PollUrl'] = $msg["pollurl"];
-					$payment_meta['PaynowReference'] = $msg["paynowreference"];
-					$payment_meta['Amount'] = $msg["amount"];
-					$payment_meta['Status'] = $msg["status"];
+					$payment_meta['PollUrl'] = $msg['pollurl'];
+					$payment_meta['PaynowReference'] = $msg['paynowreference'];
+					$payment_meta['Amount'] = $msg['amount'];
+					$payment_meta['Status'] = $msg['status'];
 
-					update_post_meta( $order_id, '_wc_paynow_payment_meta', $payment_meta );
-					
-					if ( trim(strtolower($msg["status"]) ) == ps_cancelled ){
+					update_post_meta($order_id, '_wc_paynow_payment_meta', $payment_meta);
+
+					if (trim(strtolower($msg['status'])) == PS_CANCELLED) {
 						// $order->update_status( 'cancelled',  __('Payment cancelled on Paynow.', 'woothemes' ) );
 						// $order->save();
 						return;
-					}
-					elseif ( trim(strtolower($msg["status"] ) ) == ps_failed ){
-						$order->update_status( 'failed', __('Payment failed on Paynow.', 'woothemes' ) );
+					} elseif (trim(strtolower($msg['status'])) == PS_FAILED) {
+						$order->update_status('failed', __('Payment failed on Paynow.', 'woothemes'));
 						$order->save();
 						return;
-					}
-					elseif ( trim( strtolower( $msg["status"]) ) == ps_paid || trim( strtolower( $msg["status"] ) ) == ps_awaiting_delivery || trim( strtolower( $msg["status"] ) ) == ps_delivered ){
+					} elseif (trim(strtolower($msg['status'])) == PS_PAID || trim(strtolower($msg['status'])) == PS_AWAITING_DELIVERY || trim(strtolower($msg['status'])) == PS_DELIVERED) {
 						$order->payment_complete();
 						return;
-					}
-					else {
-						// keep current state (pending payment)
-						// unknown status
-					}
-
+					} 
 				}
 			}
 		}
+	} // End wc_paynow_process_paynow_notify()
 
-
-	}// End wc_paynow_process_paynow_notify()
-	
 
 } // End Class

--- a/classes/class-wc-gateway-paynow.php
+++ b/classes/class-wc-gateway-paynow.php
@@ -6,8 +6,8 @@
  * Provides a Paynow Payment Gateway.
  *
  * @todo - Improve the naming of variables where possible
- * @class 		wc_gateway_paynow
- * @package		WooCommerce
+ * @class wc_gateway_paynow
+ * @package	WooCommerce
  * Author: Webdev
  *
  */
@@ -19,20 +19,20 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 
 	public function __construct() {
 		global $woocommerce;
-		$this->id			= 'paynow';
+		$this->id = 'paynow';
 		$this->method_title = __('Paynow', 'woothemes');
 		$this->method_description = 'Have your customers pay using Zimbabwean payment methods.';
-		$this->icon 		= $this->plugin_url() . '/assets/images/icon.png';
-		$this->has_fields 	= true;
+		$this->icon = $this->plugin_url() . '/assets/images/icon.png';
+		$this->has_fields = true;
 
 		// this is the name of the class. Mainly used in the callback to trigger wc-api handler in this class
-		$this->callback		=  strtolower(get_class($this));
+		$this->callback	=  strtolower(get_class($this));
 
 		// Setup available countries.
-		$this->available_countries = array('ZW');
+		$this->available_countries = array( 'ZW' );
 
 		// Setup available currency codes.
-		$this->available_currencies = array('USD', 'ZWL'); // nostro / rtgs ?
+		$this->available_currencies = array( 'USD', 'ZWL' ); // nostro / rtgs ?
 
 		// Load the form fields.
 		$this->init_form_fields();
@@ -53,19 +53,19 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		$this->title = $this->settings['title'];
 
 		// this is the url paynow will send it's response to
-		$this->response_url	= add_query_arg('wc-api', $this->callback, home_url('/'));
+		$this->response_url = add_query_arg('wc-api', $this->callback, home_url('/'));
 
 		// register a handler for wc-api calls to this payment method
-		add_action('woocommerce_api_' . $this->callback, array(&$this, 'paynow_checkout_return_handler'));
+		add_action('woocommerce_api_' . $this->callback, array( $this, 'paynow_checkout_return_handler' ));
 
 		/* 1.6.6 */
-		add_action('woocommerce_update_options_payment_gateways', array($this, 'process_admin_options'));
+		add_action('woocommerce_update_options_payment_gateways', array( $this, 'process_admin_options' ));
 
 		/* 2.0.0 */
-		add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
+		add_action('woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ));
 
 
-		add_action('woocommerce_receipt_paynow', array($this, 'receipt_page'));
+		add_action('woocommerce_receipt_paynow', array( $this, 'receipt_page' ));
 
 		// Check if the base currency supports this gateway.
 		if (!$this->is_valid_for_use()) {
@@ -86,50 +86,50 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 				'label' => __('Enable Paynow', 'woothemes'),
 				'type' => 'checkbox',
 				'description' => __('This controls whether or not this gateway is enabled within WooCommerce.', 'woothemes'),
-				'default' => 'yes'
+				'default' => 'yes',
 			),
 			'title' => array(
 				'title' => __('Title', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This controls the title which the user sees during checkout.', 'woothemes'),
-				'default' => __('Paynow', 'woothemes')
+				'default' => __('Paynow', 'woothemes'),
 			),
 			'description' => array(
 				'title' => __('Description', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This controls the description which the user sees during checkout.', 'woothemes'),
-				'default' => ''
+				'default' => '',
 			),
 			'merchant_id' => array(
 				'title' => __('Merchant ID (local)', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This is the merchant ID, received from Paynow.', 'woothemes'),
-				'default' => ''
+				'default' => '',
 			),
 			'merchant_key' => array(
 				'title' => __('Merchant Key (local)', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This is the merchant key, received from Paynow.', 'woothemes'),
-				'default' => ''
+				'default' => '',
 			),
 			'forex_merchant_id' => array(
 				'title' => __('Merchant ID (USD)', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This is the merchant ID, received from Paynow.', 'woothemes'),
-				'default' => ''
+				'default' => '',
 			),
 			'forex_merchant_key' => array(
 				'title' => __('Merchant Key (USD)', 'woothemes'),
 				'type' => 'text',
 				'description' => __('This is the merchant key, received from Paynow.', 'woothemes'),
-				'default' => ''
+				'default' => '',
 			),
 			'paynow_initiate_transaction_url' => array(
 				'title' => __('Paynow Initiate Transaction URL', 'woothemes'),
 				'type' => 'text',
 				'label' => __('Paynow Initiate Transaction URL.', 'woothemes'),
-				'default' => 'https://www.paynow.co.zw/Interface/InitiateTransaction'
-			)
+				'default' => 'https://www.paynow.co.zw/Interface/InitiateTransaction',
+			),
 		);
 	} // End init_form_fields()
 
@@ -144,11 +144,11 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		}
 
 		if (is_ssl()) {
-			$this->plugin_url = str_replace('http://', 'https://', WP_PLUGIN_URL) . '/' . plugin_basename(dirname(dirname(__FILE__)));
+			$this->plugin_url = str_replace('http://', 'https://', WP_PLUGIN_URL) . '/' . plugin_basename(dirname(dirname(__DIR__)));
 
 			return $this->plugin_url;
 		} else {
-			$this->plugin_url = WP_PLUGIN_URL . '/' . plugin_basename(dirname(dirname(__FILE__)));
+			$this->plugin_url = WP_PLUGIN_URL . '/' . plugin_basename(dirname(dirname(__DIR__)));
 			return $this->plugin_url;
 		}
 	} // End plugin_url()
@@ -224,7 +224,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 			?>
 			<div class="inline error">
 			<?php /* translators: %s: Disabled Gateway */ ?>
-				<p><strong><?php esc_html_e('Gateway Disabled', 'woothemes'); ?></strong> <?php echo sprintf(esc_html_e('Choose United States Dollar ($/USD) as your store currency in <a href="%s">Pricing Options</a> to enable the Paynow Gateway.', 'woocommerce'), esc_html_e(admin_url('?page=woocommerce&tab=catalog'))); ?></p>
+				<p><strong><?php esc_html_e('Gateway Disabled', 'woothemes'); ?></strong> <?php sprintf(esc_html_e('Choose United States Dollar ($/USD) as your store currency in <a href="%s">Pricing Options</a> to enable the Paynow Gateway.', 'woocommerce'), esc_html_e(admin_url('?page=woocommerce&tab=catalog'))); ?></p>
 			</div>
 		<?php
 		} // End check currency
@@ -250,12 +250,12 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 	 * @param string $from tells process payment whether the method call is from paynow return (callback) or not
 	 * @since 1.0.0
 	 */
-	public function process_payment( $order_id) {
+	public function process_payment( $order_id ) {
 
 		$order = wc_get_order($order_id);
 		return array(
-			'result' 	=> 'success',
-			'redirect'	=> $order->get_checkout_payment_url(true)
+			'result' => 'success',
+			'redirect' => $order->get_checkout_payment_url(true),
 		);
 	}
 
@@ -266,7 +266,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 	 *
 	 * @since 1.0.0
 	 */
-	public function receipt_page( $order_id) {
+	public function receipt_page( $order_id ) {
 		global $woocommerce;
 
 		//get current order
@@ -291,22 +291,22 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 			// Setup Paynow arguments
 
 			if ('USD' == $order_currency) {
-				$MerchantId =       $this->forex_merchant_id;
-				$MerchantKey =    	$this->forex_merchant_key;
+				$MerchantId = $this->forex_merchant_id;
+				$MerchantKey = $this->forex_merchant_key;
 			} else {
-				$MerchantId =       $this->merchant_id;
-				$MerchantKey =    	$this->merchant_key;
+				$MerchantId = $this->merchant_id;
+				$MerchantKey = $this->merchant_key;
 			}
 
 			// $this->log('Merchant ID:' . $MerchantId);
 
-			$ConfirmUrl =       $listener_url;
-			$ReturnUrl =        $return_url;
-			$Reference =        'Order Number: ' . $order->get_order_number();
-			$Amount =           $order->get_total();
-			$AdditionalInfo =   '';
-			$Status =           'Message';
-			$custEmail = 		$order->billing_email;
+			$ConfirmUrl =  $listener_url;
+			$ReturnUrl = $return_url;
+			$Reference = 'Order Number: ' . $order->get_order_number();
+			$Amount = $order->get_total();
+			$AdditionalInfo = '';
+			$Status = 'Message';
+			$custEmail = $order->get_billing_email();
 
 			//set POST variables
 			$values = array(
@@ -317,7 +317,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 				'id' => $MerchantId,
 				'additionalinfo' => $AdditionalInfo,
 				'authemail' => $custEmail, // customer email
-				'status' => $Status
+				'status' => $Status,
 			);
 
 			// should probably use static methods to have WC_Paynow_Helper::CreateMsg($a, $b);
@@ -325,12 +325,13 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 
 			$url = $this->initiate_transaction_url;
 
-			// send API post request
-			$response = wp_remote_request($url, [
+			$response_fields = array(
 				'timeout' => 45,
 				'method' => 'POST',
-				'body' => $fields_string
-			]);
+				'body' => $fields_string,
+			);
+			// send API post request
+			$response = wp_remote_request($url, $response_fields);
 
 			// get the response from paynow
 			$result = $response['body'];
@@ -390,7 +391,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 	 * @since 1.0.0
 	 */
 
-	public function log( $message, $close = false) {
+	public function log( $message, $close = false ) {
 
 		static $fh = 0;
 
@@ -437,12 +438,13 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 		if ($payment_meta) {
 			$url = $payment_meta['PollUrl'];
 
-			//execute post
-			$response = wp_remote_request($url, [
+			$request_fields = array(
 				'timeout' => 45,
 				'method' => 'POST',
-				'body' => ''
-			]);
+				'body' => '',
+			);
+			//execute post
+			$response = wp_remote_request($url, $request_fields);
 
 			$result = $response['body'];
 
@@ -483,6 +485,4 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway {
 			}
 		}
 	} // End wc_paynow_process_paynow_notify()
-
-
 } // End Class

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -1,12 +1,42 @@
 <?php
 //Define Constants
-define('WC_PAYNOW_VERSION', '1.2.0');
-define('ps_error', 'error');
-define('ps_ok','ok');
-define('ps_created_but_not_paid','created but not paid');
-define('ps_cancelled','cancelled');
-define('ps_failed','failed');
-define('ps_paid','paid');
-define('ps_awaiting_delivery','awaiting delivery');
-define('ps_delivered','delivered');
-define('ps_awaiting_redirect','awaiting redirect');
+// Define Constants if not defined already
+if (!defined('WC_PAYNOW_VERSION')) {
+	define('WC_PAYNOW_VERSION', '1.2.0');
+}
+
+if (!defined('PS_ERROR')) {
+	define('PS_ERROR', 'error');
+}
+
+if (!defined('PS_OK')) {
+	define('PS_OK', 'ok');
+}
+
+if (!defined('PS_CREATED_BUT_NOT_PAID')) {
+	define('PS_CREATED_BUT_NOT_PAID', 'created but not paid');
+}
+
+if (!defined('PS_CANCELLED')) {
+	define('PS_CANCELLED', 'cancelled');
+}
+
+if (!defined('PS_FAILED')) {
+	define('PS_FAILED', 'failed');
+}
+
+if (!defined('PS_PAID')) {
+	define('PS_PAID', 'paid');
+}
+
+if (!defined('PS_AWAITING_DELIVERY')) {
+	define('PS_AWAITING_DELIVERY', 'awaiting delivery');
+}
+
+if (!defined('PS_DELIVERED')) {
+	define('PS_DELIVERED', 'delivered');
+}
+
+if (!defined('PS_AWAITING_REDIRECT')) {
+	define('PS_AWAITING_REDIRECT', 'awaiting redirect');
+}

--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -73,9 +73,9 @@ return;
 		}
 
 		public function init() {
-			include_once dirname(__DIR__) . '/classes/class-wc-gateway-paynow.php';
-			include_once dirname(__DIR__) . '/classes/class-wc-gateway-paynow-helper.php';
-			include_once dirname(__DIR__) . '/includes/constants.php';
+			include_once __DIR__ . '/classes/class-wc-gateway-paynow.php';
+			include_once __DIR__ . '/classes/class-wc-gateway-paynow-helper.php';
+			include_once __DIR__ . '/includes/constants.php';
 
 			/**
 			 * Custom currency and currency symbol

--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -11,7 +11,7 @@
 	Tested up to: 4.1
 */
 
-add_action( 'plugins_loaded', 'woocommerce_paynow_init' );
+add_action('plugins_loaded', 'woocommerce_paynow_init');
 
 /**
  * Initialize the gateway.
@@ -19,23 +19,33 @@ add_action( 'plugins_loaded', 'woocommerce_paynow_init' );
  * @since 1.0.0
  */
 function woocommerce_paynow_init() {
-	load_plugin_textdomain( 'wc_paynow', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
+	load_plugin_textdomain('wc_paynow', false, trailingslashit(dirname(plugin_basename(__FILE__))));
 
-	// Check if woocommerce is installed and available for use
-	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins', array() ) );
+	/** Check if woocommerce is installed and available for use 
+	 * 
+	 * @since 1.0.0
+	*/
+	$active_plugins = apply_filters('active_plugins', get_option('active_plugins', array()));
 
-	if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins ) ) {
-		if ( ! is_multisite() ) return; // nothing more to do. Plugin not available
+	if (! in_array('woocommerce/woocommerce.php', $active_plugins) ) {
+		if (! is_multisite() ) {
+return; // nothing more to do. Plugin not available
+		}
 		
-		$site_wide_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+		$site_wide_plugins = array_keys(get_site_option('active_sitewide_plugins', array()));
 		
-		if ( ! in_array( 'woocommerce/woocommerce.php', $site_wide_plugins ) ) return;
+		if (! in_array('woocommerce/woocommerce.php', $site_wide_plugins) ) {
+return;
+		}
 		
 	};
 
 	class WC_Paynow {
+	
 
-		/**
+		/** 
+		 * Get Paynow instance
+		 * 
 		 * @var Singleton The reference the *Singleton* instance of this class
 		 */
 		private static $instance;
@@ -46,48 +56,50 @@ function woocommerce_paynow_init() {
 		 * @return Singleton The *Singleton* instance.
 		 */
 		public static function get_instance() {
-			if ( null === self::$instance ) {
+			if (null === self::$instance ) {
 				self::$instance = new self();
 			}
 			return self::$instance;
 		}
 
-		public function __clone(){}
+		public function __clone() {
+		}
 
-		public function __wakeup() {}
+		public function __wakeup() {
+		}
 
-		public function __construct()
-		{
+		public function __construct() {
 			$this->init();
 		}
 
-		public function init()
-		{
-			require_once dirname( __FILE__ ) . '/classes/class-wc-gateway-paynow.php';
-			require_once dirname( __FILE__ ) . '/classes/class-wc-gateway-paynow-helper.php';
-			require_once dirname( __FILE__ ) . '/includes/constants.php';
+		public function init() {
+			include_once dirname(__FILE__) . '/classes/class-wc-gateway-paynow.php';
+			include_once dirname(__FILE__) . '/classes/class-wc-gateway-paynow-helper.php';
+			include_once dirname(__FILE__) . '/includes/constants.php';
 
 			/**
 			 * Custom currency and currency symbol
 			 */
-			add_filter( 'woocommerce_currencies', 'add_zwl_currency' );
+			add_filter('woocommerce_currencies', 'add_zwl_currency');
 
 			function add_zwl_currency( $currencies ) {
-				$currencies['ZWL'] = __( 'Zimbabwe', 'woocommerce' );
+				$currencies['ZWL'] = __('Zimbabwe', 'woocommerce');
 				return $currencies;
 			}
 
 			add_filter('woocommerce_currency_symbol', 'add_zwl_currency_symbol', 10, 2);
 
 			function add_zwl_currency_symbol( $currency_symbol, $currency ) {
-				switch( $currency ) {
-					case 'ZWL': $currency_symbol = 'ZWL'; break;
+				switch ( $currency ) {
+					case 'ZWL': 
+						$currency_symbol = 'ZWL'; 
+						break;
 				}
 				return $currency_symbol;
 			}
 
-			add_filter('woocommerce_payment_gateways', array ($this, 'woocommerce_paynow_add_gateway' ) );
-			add_action( 'woocommerce_thankyou', array( $this, 'order_cancelled_redirect' ), 10 , 1);
+			add_filter('woocommerce_payment_gateways', array ($this, 'woocommerce_paynow_add_gateway' ));
+			add_action('woocommerce_thankyou', array( $this, 'order_cancelled_redirect' ), 10, 1);
 		}
 
 		/**
@@ -95,20 +107,20 @@ function woocommerce_paynow_init() {
 		 *
 		 * @since 1.0.0
 		 */
-		function woocommerce_paynow_add_gateway( $methods ) {
+		public function woocommerce_paynow_add_gateway( $methods ) {
 			$methods[] = 'WC_Gateway_Paynow';
 			return $methods;
 		} // End woocommerce_paynow_add_gateway()
 
-		function order_cancelled_redirect( $order_id ){
+		public function order_cancelled_redirect( $order_id ) {
 			global $woocommerce;
 			$order = new WC_Order($order_id);
-			$meta = get_post_meta( $order_id, '_wc_paynow_payment_meta', true );
+			$meta = get_post_meta($order_id, '_wc_paynow_payment_meta', true);
 			
-			if ( !empty($meta['Status']) && strtolower( $meta['Status'] ) == ps_cancelled ) {
-				wc_add_notice( __( 'You cancelled your payment on Paynow.', 'woocommerce' ), 'error' );
+			if (!empty($meta['Status']) && strtolower($meta['Status']) == PS_CANCELLED ) {
+				wc_add_notice(__('You cancelled your payment on Paynow.', 'woocommerce'), 'error');
 				// wp_redirect( $order->get_cancel_order_url() );
-				wp_redirect( $order->get_checkout_payment_url() );
+				wp_redirect($order->get_checkout_payment_url());
 			}
 		}
 

--- a/paynow-for-woocommerce.php
+++ b/paynow-for-woocommerce.php
@@ -73,9 +73,9 @@ return;
 		}
 
 		public function init() {
-			include_once dirname(__FILE__) . '/classes/class-wc-gateway-paynow.php';
-			include_once dirname(__FILE__) . '/classes/class-wc-gateway-paynow-helper.php';
-			include_once dirname(__FILE__) . '/includes/constants.php';
+			include_once dirname(__DIR__) . '/classes/class-wc-gateway-paynow.php';
+			include_once dirname(__DIR__) . '/classes/class-wc-gateway-paynow-helper.php';
+			include_once dirname(__DIR__) . '/includes/constants.php';
 
 			/**
 			 * Custom currency and currency symbol
@@ -98,7 +98,7 @@ return;
 				return $currency_symbol;
 			}
 
-			add_filter('woocommerce_payment_gateways', array ($this, 'woocommerce_paynow_add_gateway' ));
+			add_filter('woocommerce_payment_gateways', array( $this, 'woocommerce_paynow_add_gateway' ));
 			add_action('woocommerce_thankyou', array( $this, 'order_cancelled_redirect' ), 10, 1);
 		}
 
@@ -123,9 +123,7 @@ return;
 				wp_redirect($order->get_checkout_payment_url());
 			}
 		}
-
 	}
 
 	WC_Paynow::get_instance();
-	
 } // End woocommerce_paynow_init()


### PR DESCRIPTION
Steps to test

composer require woocommerce/woocommerce-sniffs 

add this file 
https://gist.github.com/mattyza/c0ac6244ad799fe8c7df1f513b99940e

 php ./vendor/bin/phpcs --standard=pbs-rules-set.xml --warning-severity=0 --report-source --report-full=phpcs-report.txt --ignore-annotations --extensions=php,html plugins/Paynow-for-WooCommerce