### PR TITLE
fix: Use WordPress rest_url() for dynamic REST API endpoint URLs

### DIFF
--- a/includes/class-wc-gateway-paynow.php
+++ b/includes/class-wc-gateway-paynow.php
@@ -1077,7 +1077,7 @@ class WC_Gateway_Paynow extends WC_Payment_Gateway
 						method: 'POST'
 					};
 
-					fetch('/wp-json/wc-paynow-express/v1/order/<?php echo $order_id; ?>', params)
+					fetch('<?php echo esc_url(rest_url('wc-paynow-express/v1/order/' . $order_id)); ?>', params)
 						.then(function(res) {
 
 							return res.json();


### PR DESCRIPTION
The PayNow checkout process was failing because the JavaScript code was using a hardcoded URL path for the REST API endpoint. This caused 404 errors when WordPress is installed in a subdirectory.

Changes made:
- Replaced hardcoded '/wp-json/wc-paynow-express/v1/order/{id}' with WordPress's rest_url() function

This change ensures the checkout process works correctly regardless of where WordPress is installed (root domain or subdirectory).